### PR TITLE
Modifying name from resinApp.sh to app.sh to match what is called in …

### DIFF
--- a/ubuntu-xorg/entry.sh
+++ b/ubuntu-xorg/entry.sh
@@ -82,9 +82,9 @@ function init_systemd()
 		printf '%q="%q"\n' "$var" "${!var}"
 	done > /etc/docker.env
 
-	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
-	printf '%q ' "$@" >> /etc/resinApp.sh
-	chmod +x /etc/resinApp.sh
+	printf '#!/bin/bash\n exec ' > /etc/app.sh
+	printf '%q ' "$@" >> /etc/app.sh
+	chmod +x /etc/app.sh
 
 	mkdir -p /etc/systemd/system/launch.service.d
 	cat <<-EOF > /etc/systemd/system/launch.service.d/override.conf


### PR DESCRIPTION
…launch.service

**Side-Note:** The original entry.sh from resin (for debian) has a few differences compared to this one, but they appeared to be intentional changes, so I didn't update the whole file. However, it does mean that the debian versions are different than the Ubuntu versions of these images.

Resin File: https://github.com/resin-io-library/base-images/blob/130534abf05b6b0bee90b071c4c0b2beb19839c4/debian/entry.sh